### PR TITLE
Added the 'SENT' function that was forgotten.

### DIFF
--- a/sms.sh
+++ b/sms.sh
@@ -6,17 +6,33 @@ if [ ! -d "$log_dir" ]; then
     mkdir -p "$log_dir"
 fi
 
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <event_type> <input_file>"
+    exit 1
+fi
+
 event_type="$1"
 input_file="$2"
 
 function runHandler() {
     case "$1" in
         RECEIVED)
-            timestamp=$(date +"%Y%m%d%H%M%S") # Получить текущую дату и время без разделителей
-            log_file="$log_dir/received_$timestamp.txt" # Уникальное имя файла на основе времени
+            timestamp=$(date +"%Y%m%d%H%M%S")  
+            log_file="$log_dir/received_$timestamp.txt" 
             echo "Timestamp: $timestamp" >> "$log_file"
             head -5 "$input_file" | grep -e "^From: " -e "^Received: " >> "$log_file"
             if grep "Alphabet: UCS2" "$input_file" > /dev/null; then
+                sed -e '1,/^$/ d' "$input_file" | recode UCS-2..utf8 >> "$log_file"
+            else
+                sed -e '1,/^$/ d' "$input_file" >> "$log_file"
+            fi
+            echo "========================================" >> "$log_file"
+            ;;
+        SENT)
+            timestamp=$(date +"%Y%m%d%H%M%S")
+            log_file="$log_dir/send_$timestamp.txt"
+            echo "Timestamp: $timestamp" >> "$log_file"
+            if grep "Alphabet: UCS" "$input_file" > /dev/null; then
                 sed -e '1,/^$/ d' "$input_file" | recode UCS-2..utf8 >> "$log_file"
             else
                 sed -e '1,/^$/ d' "$input_file" >> "$log_file"
@@ -35,7 +51,7 @@ function Run() {
         echo "Usage: $0 <event_type> <input_file>"
         exit 1
     fi
-    runHandler "$1" "$2" 
+    runHandler "$1" "$2"
 }
 
-Run "$event_type" "$input_file" 
+Run "$event_type" "$input_file"


### PR DESCRIPTION
Added a Bash script for handling SMS events

This script is designed to handle various SMS events, such as "RECEIVED" and "SENT." It creates separate log files for each event and includes the date and time in the log entry. Each log file is named based on the timestamp to ensure uniqueness.

Key Details:
- For the "RECEIVED" event, the log file is named "received_<timestamp>.txt."
- For the "SENT" event, the log file is named "send_<timestamp>.txt."

The script also provides the ability to exit by entering "exit."

Author: Sergey Zhyltsov

Please consider mentioning future feature additions if there are specific plans for extending the script's functionality.
